### PR TITLE
fix mixin extras load order issue

### DIFF
--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -2,6 +2,7 @@ import io.github.coolcrabs.brachyura.decompiler.BrachyuraDecompiler;
 import io.github.coolcrabs.brachyura.decompiler.fernflower.FernflowerDecompiler;
 import io.github.coolcrabs.brachyura.fabric.FabricContext.ModDependencyCollector;
 import io.github.coolcrabs.brachyura.fabric.FabricContext.ModDependencyFlag;
+import io.github.coolcrabs.brachyura.fabric.FabricContext;
 import io.github.coolcrabs.brachyura.fabric.FabricLoader;
 import io.github.coolcrabs.brachyura.maven.Maven;
 import io.github.coolcrabs.brachyura.maven.MavenId;
@@ -12,6 +13,8 @@ import io.github.coolcrabs.brachyura.quilt.SimpleQuiltProject;
 import net.fabricmc.mappingio.tree.MappingTree;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Buildscript extends SimpleQuiltProject {
     @Override
@@ -41,6 +44,27 @@ public class Buildscript extends SimpleQuiltProject {
         jij(d.addMaven("https://jitpack.io/", new MavenId("com.github.Fallen-Breath", "conditional-mixin", Versions.CONDITIONAL_MIXIN_VERSION), ModDependencyFlag.COMPILE, ModDependencyFlag.RUNTIME));
         // LazyDFU
         d.addMaven("https://api.modrinth.com/maven/", new MavenId("maven.modrinth", "lazydfu", Versions.LAZYDFU_VERSION), ModDependencyFlag.RUNTIME);
+    }
+
+    @Override
+    protected FabricContext createContext() {
+        return new SimpleQuiltContext(){
+            @Override
+            public List<Path> getCompileDependencies() {
+                List<Path> paths = super.getCompileDependencies();
+                ArrayList<Path> a = new ArrayList<>();
+                ArrayList<Path> b = new ArrayList<>();
+                for (Path p : paths) {
+                    if (p.getFileName().toString().contains("MixinExtras")) {
+                        a.add(p);
+                    } else {
+                        b.add(p);
+                    }
+                }
+                a.addAll(b);
+                return a;
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
When mixin extras loads after mixin MixinObfuscationProcessorInjection.getSupportedAnnotationTypes() does not contain the additional mixin types.