### PR TITLE
More JDK 21 migrations, Bump other dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,12 @@ on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v3
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
@@ -17,7 +17,7 @@ jobs:
         java-version: 21
         check-latest: true
     - name: Cache Gradle configuration
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: | 
           ~/.gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,12 @@ on:
 jobs:
   publish:
     runs-on:
-      ubuntu-latest
+      ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -21,7 +21,7 @@ jobs:
           java-version: 21
           check-latest: true
       - name: Cache Gradle configuration
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
     implementation("com.h2database:h2:${project.h2_version}")
     implementation("org.ow2.asm:asm-tree:${project.asm_version}")
-    implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.3.3"))
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.3.5"))
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/common/src/main/resources/vanilla_disable.mixins.json
+++ b/common/src/main/resources/vanilla_disable.mixins.json
@@ -4,7 +4,7 @@
   "package": "uk.debb.vanilla_disable.mixin",
   "plugin": "uk.debb.vanilla_disable.mixin_plugin.VanillaDisableMixinPlugin",
   "refmap": "${mod_id}.refmap.json",
-  "compatibilityLevel": "JAVA_18",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "command.advancement.MixinPlayerAdvancements",
     "command.block.command.MixinFillCommand",

--- a/fabric/src/main/resources/vanilla_disable.fabric.mixins.json
+++ b/fabric/src/main/resources/vanilla_disable.fabric.mixins.json
@@ -4,7 +4,7 @@
   "package": "uk.debb.vanilla_disable.mixin",
   "plugin": "uk.debb.vanilla_disable.mixin_plugin.VanillaDisableMixinPlugin",
   "refmap": "${mod_id}.refmap.json",
-  "compatibilityLevel": "JAVA_18",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "command.block.placement.MixinBucketItem",
     "util.gamerule.MixinEditGameRulesScreenRuleList"

--- a/gradlew
+++ b/gradlew
@@ -200,7 +200,7 @@ fi
 
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='-Dfile.encoding=UTF-8 "-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -34,7 +34,7 @@ set APP_HOME=%DIRNAME%
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+set DEFAULT_JVM_OPTS=-Dfile.encoding=UTF-8 "-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
@@ -43,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 

--- a/neoforge/src/main/resources/vanilla_disable.neoforge.mixins.json
+++ b/neoforge/src/main/resources/vanilla_disable.neoforge.mixins.json
@@ -4,7 +4,7 @@
   "package": "uk.debb.vanilla_disable.mixin",
   "plugin": "uk.debb.vanilla_disable.mixin_plugin.VanillaDisableMixinPlugin",
   "refmap": "${mod_id}.refmap.json",
-  "compatibilityLevel": "JAVA_18",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "command.block.placement.MixinBucketItem",
     "util.gamerule.MixinEditGameRulesScreenRuleList"


### PR DESCRIPTION
1. Sets the OS version to a frozen version in case 24.04 may cause problems in workflows,
2. Superseds `gradle/wrapper-validation-action` with `gradle/actions/wrapper-validation` instead,
3. Updates `actions/cache` to v4,
4. Updates MixinExtras to 0.3.5,
5. Upstreams gradlew scripts and sets `JAVA_18` mixin files -> `JAVA_21`.

*(There is currently an error which is `[MIXIN] Cannot resolve class io/netty/buffer/ByteBuf` but i cannot solve this on my own rn so consider this a bit of a bummer)*